### PR TITLE
Fix error on remote ssh server

### DIFF
--- a/src/Task/Remote/Ssh.php
+++ b/src/Task/Remote/Ssh.php
@@ -184,7 +184,7 @@ class Ssh extends BaseTask implements CommandInterface
             $hostSpec = $this->user . '@' . $hostSpec;
         }
 
-        return sprintf("ssh{$sshOptions} {$hostSpec} '{$command}'");
+        return sprintf("ssh{$sshOptions} {$hostSpec} \"{$command}\"");
     }
 
 }


### PR DESCRIPTION
SSH error: remote ssh server of windows local machine responds: command " name' " not found. (with single quote at the end)
That update fix it!